### PR TITLE
Fixed pkg-config name libcrypto++ to libcryptopp

### DIFF
--- a/Source/Core/CMakeLists.txt
+++ b/Source/Core/CMakeLists.txt
@@ -34,7 +34,7 @@ if (BUNDLED_CRYPTOPP)
 else()
     find_package(PkgConfig)
 
-    pkg_check_modules(CRYPTOPP REQUIRED libcrypto++)
+    pkg_check_modules(CRYPTOPP REQUIRED libcryptopp)
     target_include_directories("CoreLib" PRIVATE "${CRYPTOPP_INCLUDEDIR}")
     target_link_libraries("CoreLib" ${CRYPTOPP_LDFLAGS})
 endif()


### PR DESCRIPTION
Fixed missnamed libcrypto++ pkg-config file. 
You can see in crypto's github repository that it's named libcryptopp https://github.com/weidai11/cryptopp/blob/b30600683178f613de9f72071d5d61bbb7ba0e0e/GNUmakefile#L1423-L1437